### PR TITLE
Handle shorthand hex colors

### DIFF
--- a/src/hexToRgb.js
+++ b/src/hexToRgb.js
@@ -1,10 +1,15 @@
 // credits go to https://stackoverflow.com/a/5624139/491075
 export const hexToRgb = hex => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+  // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+  var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+  hex = hex.replace(shorthandRegex, (m, r, g, b) => {
+    return r + r + g + g + b + b;
+  });
 
+  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result ? {
     r: parseInt(result[1], 16),
     g: parseInt(result[2], 16),
     b: parseInt(result[3], 16),
-  } : null
+  } : null;
 }

--- a/test/hexToRgb.js
+++ b/test/hexToRgb.js
@@ -39,15 +39,111 @@ describe('hexToRgb', function() {
 
       expect(result).to.deep.equal(expectedResult)
     });
+
+    it('should ignore case', function() {
+      var color = '#FffFFf';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 255,
+        b: 255
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+
+    it('should handle color without #', function() {
+      var color = 'ffffff';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 255,
+        b: 255
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
   });
 
+  describe('converting valid shorthand colors', function() {
+    it('should convert black', function() {
+      var color = '#000';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 0,
+        g: 0,
+        b: 0
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+
+    it('should convert white', function() {
+      var color = '#fff';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 255,
+        b: 255
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+
+    it('should convert red', function() {
+      var color = '#f00';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 0,
+        b: 0
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+
+    it('should ignore case', function() {
+      var color = '#FfF';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 255,
+        b: 255
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+
+    it('should handle color without #', function() {
+      var color = 'fff';
+      var result = hexToRgb(color);
+      var expectedResult = {
+        r: 255,
+        g: 255,
+        b: 255
+      };
+
+      expect(result).to.deep.equal(expectedResult)
+    });
+  })
+
   describe('converting invalid colors', function() {
-    it('should return null', function() {
-      var color = '#gahsrgas';
+    it('should return null for invalid hex characters', function() {
+      var color = '#gahsrg';
       var result = hexToRgb(color);
       var expectedResult = null
 
       expect(result).to.equal(expectedResult)
+    });
+
+    it('should return null for invalid length', function() {
+      for (const length of [0, 1, 2, 4, 5, 7]) {
+        var color = 'f'.repeat(length);
+        var result = hexToRgb(color);
+        var expectedResult = null
+
+        expect(result).to.equal(expectedResult)
+      }
     });
   });
 


### PR DESCRIPTION
fixes #4 

This adds handling for shorthand hex codes, by copying the updated answer from the [stackoverflow answer](https://stackoverflow.com/a/5624139)

Making this PR as an offering, in the hopes that a new package version could be published to npm so I can use the `index.d.ts`, which was added after the most recent release